### PR TITLE
Improved SP download handling

### DIFF
--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -446,7 +446,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_length,
         (*packet_count)++;
 	*packets = packet;
 	*packet_count = 1;
-        netmd_log(NETMD_LOG_VERBOSE, "Encrypting data: %d bytes\n", *packet_count, packet->length);
+        netmd_log(NETMD_LOG_VERBOSE, "Encrypted %d bytes\n", packet->length);
 
     gcry_cipher_close(key_handle);
     gcry_cipher_close(data_handle);

--- a/libnetmd/secure.h
+++ b/libnetmd/secure.h
@@ -55,7 +55,6 @@ typedef struct netmd_track_packets {
     size_t length;
 
     /** next packet to transfer (linked list) */
-    struct netmd_track_packets *next;
 } netmd_track_packets;
 
 /**
@@ -147,9 +146,7 @@ netmd_error netmd_secure_send_track(netmd_dev_handle *dev,
                                     unsigned char discformat,
                                     unsigned int frames,
                                     netmd_track_packets *packets,
-                                    size_t packet_length,
                                     unsigned char *sessionkey,
-
                                     uint16_t *track, unsigned char *uuid,
                                     unsigned char *content_id);
 

--- a/netmdcli/netmdcli.c
+++ b/netmdcli/netmdcli.c
@@ -505,7 +505,7 @@ int main(int argc, char* argv[])
             fclose(f);
         }
         else if (strcmp("send", argv[1]) == 0) {
-            if (!check_args(argc, 2, "send")) return -1;
+            if (!check_args(argc, 3, "send")) return -1;
             netmd_error error;
                     netmd_ekb ekb;
                     unsigned char chain[] = {0x25, 0x45, 0x06, 0x4d, 0xea, 0xca,
@@ -689,7 +689,7 @@ int main(int argc, char* argv[])
                         error = netmd_secure_send_track(devh, wireformat,
                                                         discformat,
                                                         frames, packets,
-                                                        packet_length, sessionkey,
+							sessionkey,
                                                         &track, uuid, new_contentid);
                         netmd_log(NETMD_LOG_VERBOSE, "netmd_secure_send_track : %s\n", netmd_strerror(error));
 
@@ -698,8 +698,8 @@ int main(int argc, char* argv[])
                         free(data);
                         audio_data = NULL;
 
-                        /* set title, use filename */
-                        memcpy(title, argv[2], strlen(argv[2])-4);
+                        /* set title, use argument from command line */
+                        memcpy(title, argv[3], strlen(argv[3]));
                         netmd_log(NETMD_LOG_VERBOSE, "New Track: %d\n", track);
                         netmd_cache_toc(devh);
                         netmd_set_title(devh, track, title);
@@ -956,15 +956,17 @@ void print_syntax()
     puts("stop - stop the unit");
     puts("delete #1 - delete track");
     puts("m3uimport - import playlist - and title current disc using it.");
-    puts("send #1 - send wav audio file #1 to the device");
-    puts("          #1 supported files: 16 bit pcm (stere or mono) @44100Hz or");
+    puts("send #1 #2 - send wav audio file #1 to the device");
+    puts("          #1 supported files: 16 bit pcm (stereo or mono) @44100Hz or");
     puts("          Atrac LP2/LP4 stored in a wav container");
+    puts("          #2 Title");
     puts("raw - send raw command (hex)");
     puts("setplaymode (single, repeat, shuffle) - set play mode");
     puts("newgroup <string> - create a new group named <string>");
     puts("settitle <string> - manually set the complete disc title (with group information)");
     puts("settime <track> [<hour>] <minute> <second> [<frame>] - seeks to the given timestamp");
     puts("      (if three values are given, they are minute, second and frame)");
+    puts("capacity - shows current minidisc capacity (used, available)");
     puts("secure #1 #2 - execute secure command #1 on track #2 (where applicable)");
     puts("  --- general ---");
     puts("  0x80 = start secure session");


### PR DESCRIPTION
I've made a few changes that fixed some problems I had with the last fork, specifically audible 'pops' over the packet boundaries. I've tested the changes on SP files thouroughly, but haven't tested any LP2/LP4 files.

Please note that packet size has been reduced dramatically, to 2048 bytes in bulk usb transfer. This reduces the maximum speed at which the minidisc can write data, and decreases upload-speed from 1.6x to about realtime. An increase in blocksize immediately resulted in a 'pop' on the first packet boundary, but no noise was observed in subsequent blocks.

For more info, refer to [this issue](https://github.com/glaubitz/linux-minidisc/issues/39)